### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/spotify_terminal/authentication.py
+++ b/spotify_terminal/authentication.py
@@ -64,7 +64,7 @@ class Authenticator(object):
 
             def show_link():
                 time.sleep(5)
-                if web_thread.isAlive():
+                if web_thread.is_alive():
                     print("If stuck, visit: {}".format(self._authorize_url()))
             message_thread = Thread(target=show_link)
             message_thread.start()

--- a/spotify_terminal/common.py
+++ b/spotify_terminal/common.py
@@ -299,7 +299,7 @@ class ContextDuration(object):
             return self
 
 
-SPOTIFY_BANNER = """
+SPOTIFY_BANNER = r"""
    _____             __  _ ____
   / ___/____  ____  / /_(_/ ____  __
   \__ \/ __ \/ __ \/ __/ / /_/ / / /


### PR DESCRIPTION
threading.Thread.isAlive was removed in Python 3.9 in favour of is_alive which is present in both Python 2 and 3. The PR also fixes a deprecation warning as below by adding raw string

```
find . -iname '*.py' | xargs -P4 -I{} python3.8 -Wall -m py_compile {}
./spotify_terminal/common.py:302: DeprecationWarning: invalid escape sequence \_
  SPOTIFY_BANNER = """
```